### PR TITLE
fix: use ceiling rounding for fee calculation

### DIFF
--- a/edgex_sdk/order/client.py
+++ b/edgex_sdk/order/client.py
@@ -1,5 +1,5 @@
 import time
-from decimal import Decimal
+from decimal import Decimal, ROUND_CEILING
 from typing import Dict, Any, Optional, List
 
 from ..internal.async_client import AsyncClient
@@ -92,8 +92,8 @@ class Client:
         except (ValueError, TypeError):
             raise ValueError("failed to parse fee rate")
 
-        # Calculate fee amount in decimal with 6 decimal places
-        amount_fee_dm = (value_dm * fee_rate).quantize(Decimal("0.000001"))
+        # Calculate fee amount in decimal with ceiling
+        amount_fee_dm = (value_dm * fee_rate).quantize(Decimal("0.000001"), rounding=ROUND_CEILING)
         amount_fee_str = str(amount_fee_dm)
 
         # Convert to the required integer format for the protocol


### PR DESCRIPTION
## Summary

This PR changes the fee calculation logic from default rounding to ceiling rounding (ROUND_CEILING) to ensure fee amounts are always rounded up.

## Changes

- Import `ROUND_CEILING` from decimal module
- Update fee calculation to use `rounding=ROUND_CEILING` parameter in `quantize()` method
- Update comment to reflect the ceiling rounding behavior

## Motivation

- **Conservative approach**: Ceiling rounding ensures fees are never underestimated
- **Consistency**: Aligns with Go SDK implementation behavior
- **Clarity**: The calculated amount represents the maximum fee, not the actual fee charged

## Technical Details

### Before:
```python
amount_fee_dm = (value_dm * fee_rate).quantize(Decimal("0.000001"))
```

### After:
```python
amount_fee_dm = (value_dm * fee_rate).quantize(Decimal("0.000001"), rounding=ROUND_CEILING)
```

### Example Impact:
- Raw calculation: `0.123552344704`
- Default rounding: `0.123552`
- Ceiling rounding: `0.123553` ✅

## Testing

Tested with various scenarios to verify ceiling rounding behavior:
- Exact decimal results (no change)
- Results with extra precision (rounds up)
- Edge cases with minimal precision differences

All tests pass and confirm the ceiling rounding works as expected.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author