### PR TITLE
Enforce int typecasting for account_id in client.py

### DIFF
--- a/edgex_sdk/client.py
+++ b/edgex_sdk/client.py
@@ -38,7 +38,7 @@ class Client:
         # Create async client
         self.async_client = AsyncClient(
             base_url=base_url,
-            account_id=account_id,
+            account_id=int(account_id),
             stark_pri_key=stark_private_key,
             signing_adapter=signing_adapter,
             timeout=timeout


### PR DESCRIPTION
Ensures account_id is always an integer before hash computation. Prevents downstream pedersen_hash calculation errors when string inputs are passed to limit order methods.